### PR TITLE
Apply some suggestions of static code analysis tools

### DIFF
--- a/cmd/git-prep-directory/main.go
+++ b/cmd/git-prep-directory/main.go
@@ -20,7 +20,7 @@ func main() {
 	app.Usage = "Build tools friendly way of repeatedly cloning a git\n" +
 		"   repository using a submodule cache and setting file timestamps to commit times."
 
-	app.Action = ActionMain
+	app.Action = actionMain
 
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
@@ -41,7 +41,7 @@ func main() {
 	app.RunAndExitOnError()
 }
 
-func ActionMain(c *cli.Context) {
+func actionMain(c *cli.Context) {
 	if !c.GlobalIsSet("url") || !c.GlobalIsSet("ref") {
 		log.Fatalln("Error: --url and --ref required")
 	}

--- a/determine-mod-time.go
+++ b/determine-mod-time.go
@@ -7,8 +7,8 @@ import (
 	"time"
 )
 
-// Return the most recent committed timestamp of each file in the whole of
-// history. It's faster than invoking 'git log -1' on each file.
+// CommitTimes returns the most recent committed timestamp of each file in the
+// whole of history. It's faster than invoking 'git log -1' on each file.
 func CommitTimes(gitDir, revision string) (map[string]time.Time, error) {
 	times := map[string]time.Time{}
 

--- a/git-prep-directory.go
+++ b/git-prep-directory.go
@@ -1,0 +1,79 @@
+package git
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// BuildDirectory holds the git rev and path to a cloned git repository. It also
+// holds a cleanup function to safely remove this directory.
+type BuildDirectory struct {
+	Name    string
+	Dir     string
+	Cleanup func()
+}
+
+// PrepBuildDirectory clones a given repository and checks out the given
+// revision, setting the timestamp of all files to their commit time and putting
+// all submodules into a submodule cache.
+func PrepBuildDirectory(gitDir, remote, ref string) (*BuildDirectory, error) {
+	start := time.Now()
+	defer func() {
+		log.Printf("Took %v to prep %v", time.Since(start), remote)
+	}()
+
+	if strings.HasPrefix(remote, "github.com/") {
+		remote = "https://" + remote
+	}
+
+	gitDir, err := filepath.Abs(gitDir)
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine abspath: %v", err)
+	}
+
+	err = LocalMirror(remote, gitDir, ref, os.Stderr)
+	if err != nil {
+		return nil, fmt.Errorf("unable to LocalMirror: %v", err)
+	}
+
+	rev, err := RevParse(gitDir, ref)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse rev: %v", err)
+	}
+
+	tagName, err := Describe(gitDir, rev)
+	if err != nil {
+		return nil, fmt.Errorf("unable to describe %v: %v", rev, err)
+	}
+
+	shortRev := rev[:10]
+	checkoutPath := path.Join(gitDir, filepath.Join("c/", shortRev))
+
+	err = RecursiveCheckout(gitDir, checkoutPath, rev)
+	if err != nil {
+		return nil, err
+	}
+
+	cleanup := func() {
+		err := SafeCleanup(checkoutPath)
+		if err != nil {
+			log.Println("Error cleaning up path:", checkoutPath)
+		}
+	}
+
+	return &BuildDirectory{tagName, checkoutPath, cleanup}, nil
+}
+
+// SafeCleanup recursively removes all files from a given path, which has to be
+// a subfolder of the current working directory.
+func SafeCleanup(path string) error {
+	if path == "/" || path == "" || path == "." || strings.Contains(path, "..") {
+		return fmt.Errorf("invalid path specified for deletion %q", path)
+	}
+	return os.RemoveAll(path)
+}

--- a/git.go
+++ b/git.go
@@ -136,7 +136,7 @@ func ContextRun(ctx context.Context, cmd *exec.Cmd) error {
 
 	select {
 	case <-ctx.Done():
-		cmd.Process.Kill()
+		_ = cmd.Process.Kill()
 		return ctx.Err()
 	case err := <-errc:
 		return err // err may be nil

--- a/git.go
+++ b/git.go
@@ -1,10 +1,6 @@
 package git
 
-// everything git and github related
-
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -19,8 +15,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-const GIT_BASE_DIR = "repo"
-
 // Command invokes a `command` in `workdir` with `args`, connecting Stdout and
 // Stderr to Stderr.
 func Command(workdir, command string, args ...string) *exec.Cmd {
@@ -32,54 +26,6 @@ func Command(workdir, command string, args ...string) *exec.Cmd {
 	cmd.Stderr = os.Stderr
 	return cmd
 }
-
-var (
-	ErrEmptyRepoName         = errors.New("Empty repository name")
-	ErrEmptyRepoOrganization = errors.New("Empty repository organization")
-	ErrUserNotAllowed        = errors.New("User not in the allowed set")
-)
-
-type Repository struct {
-	Name         string `json:"name"`
-	Url          string `json:"url"`
-	Organization string `json:"organization"`
-}
-
-type Pusher struct {
-	Name string `json:"name"`
-}
-
-type NonGithub struct {
-	NoBuild bool `json:"nobuild"`
-	Wait    bool `json:"wait"`
-}
-
-type JustNongithub struct {
-	NonGithub NonGithub `json:"nongithub"`
-}
-
-func ParseJustNongithub(in []byte) (j JustNongithub, err error) {
-	err = json.Unmarshal(in, &j)
-	return
-}
-
-type PushEvent struct {
-	Ref        string     `json:"ref"`
-	Deleted    bool       `json:"deleted"`
-	Repository Repository `json:"repository"`
-	After      string     `json:"after"`
-	Pusher     Pusher     `json:"pusher"`
-	NonGithub  NonGithub  `json:"nongithub"`
-	HtmlUrl    string     `json:"html_url"`
-}
-
-type GithubStatus struct {
-	State       string `json:"state"`
-	TargetUrl   string `json:"target_url"`
-	Description string `json:"description"`
-}
-
-var ErrSkipGithubEndpoint = errors.New("Github endpoint skipped")
 
 // LocalMirror creates or updates a mirror of `url` at `gitDir` using `git clone
 // --mirror`.

--- a/git.go
+++ b/git.go
@@ -84,7 +84,7 @@ var ErrSkipGithubEndpoint = errors.New("Github endpoint skipped")
 func LocalMirror(
 	url, gitDir, ref string,
 	messages io.Writer,
-) (err error) {
+) error {
 
 	// When mirroring, allow up to two minutes before giving up.
 	const MirrorTimeout = 2 * time.Minute

--- a/git.go
+++ b/git.go
@@ -103,7 +103,7 @@ func LocalMirror(
 		return Fetch(ctx, gitDir, url, messages)
 	}
 
-	err = os.MkdirAll(filepath.Dir(gitDir), 0777)
+	err := os.MkdirAll(filepath.Dir(gitDir), 0777)
 	if err != nil {
 		return err
 	}

--- a/git.go
+++ b/git.go
@@ -141,7 +141,6 @@ func ContextRun(ctx context.Context, cmd *exec.Cmd) error {
 	case err := <-errc:
 		return err // err may be nil
 	}
-	return nil
 }
 
 func Fetch(
@@ -299,7 +298,7 @@ func PrepBuildDirectory(
 	cleanup := func() {
 		err := SafeCleanup(checkoutPath)
 		if err != nil {
-			log.Printf("Error cleaning up path: ", checkoutPath)
+			log.Println("Error cleaning up path:", checkoutPath)
 		}
 	}
 

--- a/set-mtime.go
+++ b/set-mtime.go
@@ -7,6 +7,8 @@ import (
 	"time"
 )
 
+// SetMTimes changes the modification and access time of all files in a given
+// directory to their latest commit time.
 func SetMTimes(gitDir, checkoutDir, ref string) error {
 
 	commitTimes, err := CommitTimes(gitDir, ref)

--- a/set-mtime_darwin.go
+++ b/set-mtime_darwin.go
@@ -12,6 +12,7 @@ func touchDatetime(t time.Time) string {
 		t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second())
 }
 
+// Chtimes changes the modification and access time of a given file.
 func Chtimes(path string, atime, mtime time.Time) error {
 	cmd := exec.Command("touch", "-a", "-h", "-t", touchDatetime(atime), path)
 	if e := cmd.Run(); e != nil {

--- a/set-mtime_darwin.go
+++ b/set-mtime_darwin.go
@@ -15,12 +15,12 @@ func touchDatetime(t time.Time) string {
 func Chtimes(path string, atime, mtime time.Time) error {
 	cmd := exec.Command("touch", "-a", "-h", "-t", touchDatetime(atime), path)
 	if e := cmd.Run(); e != nil {
-		return &os.PathError{"futimesat", path, e}
+		return &os.PathError{Op: "futimesat", Path: path, Err: e}
 	}
 
 	cmd = exec.Command("touch", "-m", "-h", "-t", touchDatetime(mtime), path)
 	if e := cmd.Run(); e != nil {
-		return &os.PathError{"futimesat", path, e}
+		return &os.PathError{Op: "futimesat", Path: path, Err: e}
 	}
 
 	return nil

--- a/set-mtime_unix.go
+++ b/set-mtime_unix.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// Chtimes changes the modification and access time of a given file.
 func Chtimes(path string, atime, mtime time.Time) error {
 	// https://github.com/torvalds/linux/blob/2decb2682f80759f631c8332f9a2a34a02150a03/include/uapi/linux/fcntl.h#L56
 	var utimes [2]unix.Timespec

--- a/set-mtime_unix.go
+++ b/set-mtime_unix.go
@@ -16,7 +16,7 @@ func Chtimes(path string, atime, mtime time.Time) error {
 	utimes[1] = unix.NsecToTimespec(mtime.UnixNano())
 
 	if e := unix.UtimesNanoAt(unix.AT_FDCWD, path, utimes[0:], unix.AT_SYMLINK_NOFOLLOW); e != nil {
-		return &os.PathError{"futimesat", path, e}
+		return &os.PathError{Op: "futimesat", Path: path, Err: e}
 	}
 	return nil
 }

--- a/submodule.go
+++ b/submodule.go
@@ -14,10 +14,7 @@ import (
 
 // PrepSubmodules in parallel initializes all submodules and additionally stores
 // them in a local cache.
-func PrepSubmodules(
-	gitDir, checkoutDir, mainRev string,
-) error {
-
+func PrepSubmodules(gitDir, checkoutDir, mainRev string) error {
 	gitModules := filepath.Join(checkoutDir, ".gitmodules")
 
 	submodules, err := ParseSubmodules(gitModules)
@@ -101,11 +98,7 @@ func MultipleErrors(errs <-chan error) error {
 }
 
 // Checkout the working directory of a given submodule.
-func prepSubmodule(
-	mainGitDir, mainCheckoutDir string,
-	submodule Submodule,
-) error {
-
+func prepSubmodule(mainGitDir, mainCheckoutDir string, submodule Submodule) error {
 	subGitDir := filepath.Join(mainGitDir, "modules", submodule.Path)
 
 	err := LocalMirror(submodule.URL, subGitDir, submodule.Rev, os.Stderr)
@@ -125,18 +118,20 @@ func prepSubmodule(
 
 // Submodule holds the path, url, and revision to a submodule.
 type Submodule struct {
-	Path, URL string
-	Rev       string // populated by GetSubmoduleRevs
+	Path string
+	URL  string
+	Rev  string // populated by GetSubmoduleRevs
 }
 
 // ParseSubmodules returns all submodule definitions given a .gitmodules
 // configuration.
-func ParseSubmodules(filename string) (submodules []Submodule, err error) {
+func ParseSubmodules(filename string) ([]Submodule, error) {
 	config, err := ini.LoadFile(filename)
 	if err != nil {
 		return nil, err
 	}
 
+	var submodules []Submodule
 	for section := range config {
 		if !strings.HasPrefix(section, "submodule") {
 			continue


### PR DESCRIPTION
An approach to break out _builder_ from _Hanoverd_. 

Preserved git history. Passes all checks from [gometalinter](https://github.com/alecthomas/gometalinter).