### PR TITLE
Allow globally setting timeout and log output writer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+/git-prep-directory
+/src

--- a/cmd/git-prep-directory/.gitignore
+++ b/cmd/git-prep-directory/.gitignore
@@ -1,2 +1,0 @@
-/git-prep-directory
-/src

--- a/cmd/git-prep-directory/main.go
+++ b/cmd/git-prep-directory/main.go
@@ -17,7 +17,7 @@ import (
 const CloneTimeout = 2 * time.Minute
 
 func init() {
-	log.SetPrefix("")
+	log.SetFlags(0)
 }
 
 func main() {

--- a/cmd/git-prep-directory/main.go
+++ b/cmd/git-prep-directory/main.go
@@ -14,7 +14,7 @@ import (
 // CloneTimeout specifies the duration allowed for each individual `git clone`
 // call (main repository mirroring or git submodule initialization) before
 // cancelling the operation.
-const CloneTimeout = 2 * time.Minute
+const CloneTimeout = 1 * time.Hour
 
 func init() {
 	log.SetFlags(0)

--- a/cmd/git-prep-directory/main.go
+++ b/cmd/git-prep-directory/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	"github.com/scraperwiki/git-prep-directory"
@@ -62,7 +63,8 @@ func actionMain(c *cli.Context) {
 		c.GlobalString("destination"),
 		c.GlobalString("url"),
 		c.GlobalString("ref"),
-		c.GlobalDuration("timeout"))
+		c.GlobalDuration("timeout"),
+		os.Stderr)
 	if err != nil {
 		log.Fatalln("Error:", err)
 	}

--- a/cmd/git-prep-directory/main.go
+++ b/cmd/git-prep-directory/main.go
@@ -3,11 +3,17 @@ package main
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/scraperwiki/git-prep-directory"
 
 	"github.com/codegangsta/cli"
 )
+
+// CloneTimeout specifies the duration allowed for each individual `git clone`
+// call (main repository mirroring or git submodule initialization) before
+// cancelling the operation.
+const CloneTimeout = 2 * time.Minute
 
 func init() {
 	log.SetPrefix("")
@@ -36,6 +42,12 @@ func main() {
 			Usage: "destination dir",
 			Value: "./src",
 		},
+		cli.DurationFlag{
+			Name:   "timeout, t",
+			Usage:  "clone timeout",
+			Value:  CloneTimeout,
+			EnvVar: "GIT_PREP_DIR_TIMEOUT",
+		},
 	}
 
 	app.RunAndExitOnError()
@@ -49,7 +61,8 @@ func actionMain(c *cli.Context) {
 	where, err := git.PrepBuildDirectory(
 		c.GlobalString("destination"),
 		c.GlobalString("url"),
-		c.GlobalString("ref"))
+		c.GlobalString("ref"),
+		c.GlobalDuration("timeout"))
 	if err != nil {
 		log.Fatalln("Error:", err)
 	}

--- a/git-prep-directory.go
+++ b/git-prep-directory.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path"
@@ -21,7 +22,7 @@ type BuildDirectory struct {
 // PrepBuildDirectory clones a given repository and checks out the given
 // revision, setting the timestamp of all files to their commit time and putting
 // all submodules into a submodule cache.
-func PrepBuildDirectory(gitDir, remote, ref string, timeout time.Duration) (*BuildDirectory, error) {
+func PrepBuildDirectory(gitDir, remote, ref string, timeout time.Duration, messages io.Writer) (*BuildDirectory, error) {
 	start := time.Now()
 	defer func() {
 		log.Printf("Took %v to prep %v", time.Since(start), remote)
@@ -36,7 +37,7 @@ func PrepBuildDirectory(gitDir, remote, ref string, timeout time.Duration) (*Bui
 		return nil, fmt.Errorf("unable to determine abspath: %v", err)
 	}
 
-	err = LocalMirror(remote, gitDir, ref, timeout, os.Stderr)
+	err = LocalMirror(remote, gitDir, ref, timeout, messages)
 	if err != nil {
 		return nil, fmt.Errorf("unable to LocalMirror: %v", err)
 	}
@@ -54,7 +55,7 @@ func PrepBuildDirectory(gitDir, remote, ref string, timeout time.Duration) (*Bui
 	shortRev := rev[:10]
 	checkoutPath := path.Join(gitDir, filepath.Join("c/", shortRev))
 
-	err = RecursiveCheckout(gitDir, checkoutPath, rev, timeout)
+	err = RecursiveCheckout(gitDir, checkoutPath, rev, timeout, messages)
 	if err != nil {
 		return nil, err
 	}

--- a/git-prep-directory.go
+++ b/git-prep-directory.go
@@ -21,7 +21,7 @@ type BuildDirectory struct {
 // PrepBuildDirectory clones a given repository and checks out the given
 // revision, setting the timestamp of all files to their commit time and putting
 // all submodules into a submodule cache.
-func PrepBuildDirectory(gitDir, remote, ref string) (*BuildDirectory, error) {
+func PrepBuildDirectory(gitDir, remote, ref string, timeout time.Duration) (*BuildDirectory, error) {
 	start := time.Now()
 	defer func() {
 		log.Printf("Took %v to prep %v", time.Since(start), remote)
@@ -36,7 +36,7 @@ func PrepBuildDirectory(gitDir, remote, ref string) (*BuildDirectory, error) {
 		return nil, fmt.Errorf("unable to determine abspath: %v", err)
 	}
 
-	err = LocalMirror(remote, gitDir, ref, os.Stderr)
+	err = LocalMirror(remote, gitDir, ref, timeout, os.Stderr)
 	if err != nil {
 		return nil, fmt.Errorf("unable to LocalMirror: %v", err)
 	}
@@ -54,7 +54,7 @@ func PrepBuildDirectory(gitDir, remote, ref string) (*BuildDirectory, error) {
 	shortRev := rev[:10]
 	checkoutPath := path.Join(gitDir, filepath.Join("c/", shortRev))
 
-	err = RecursiveCheckout(gitDir, checkoutPath, rev)
+	err = RecursiveCheckout(gitDir, checkoutPath, rev, timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/git-prep-directory.go
+++ b/git-prep-directory.go
@@ -3,7 +3,6 @@ package git
 import (
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -25,7 +24,7 @@ type BuildDirectory struct {
 func PrepBuildDirectory(gitDir, remote, ref string, timeout time.Duration, messages io.Writer) (*BuildDirectory, error) {
 	start := time.Now()
 	defer func() {
-		log.Printf("Took %v to prep %v", time.Since(start), remote)
+		fmt.Fprintf(messages, "Took %v to prep %v", time.Since(start), remote)
 	}()
 
 	if strings.HasPrefix(remote, "github.com/") {
@@ -63,7 +62,7 @@ func PrepBuildDirectory(gitDir, remote, ref string, timeout time.Duration, messa
 	cleanup := func() {
 		err := SafeCleanup(checkoutPath)
 		if err != nil {
-			log.Println("Error cleaning up path:", checkoutPath)
+			fmt.Fprintln(messages, "Error cleaning up path:", checkoutPath)
 		}
 	}
 

--- a/git.go
+++ b/git.go
@@ -15,10 +15,8 @@ import (
 
 // LocalMirror creates or updates a mirror of `url` at `gitDir` using `git clone
 // --mirror`.
-func LocalMirror(url, gitDir, ref string, messages io.Writer) error {
-	// When mirroring, allow up to two minutes before giving up.
-	const MirrorTimeout = 2 * time.Minute
-	ctx, done := context.WithTimeout(context.Background(), MirrorTimeout)
+func LocalMirror(url, gitDir, ref string, timeout time.Duration, messages io.Writer) error {
+	ctx, done := context.WithTimeout(context.Background(), timeout)
 	defer done()
 
 	if _, err := os.Stat(gitDir); err == nil {
@@ -158,13 +156,13 @@ func Describe(gitDir, ref string) (desc string, err error) {
 
 // RecursiveCheckout recursively checks out repositories; similar to "git clone
 // --recursive".
-func RecursiveCheckout(gitDir, checkoutPath, rev string) error {
+func RecursiveCheckout(gitDir, checkoutPath, rev string, timeout time.Duration) error {
 	err := Checkout(gitDir, checkoutPath, rev)
 	if err != nil {
 		return fmt.Errorf("failed to checkout: %v", err)
 	}
 
-	err = PrepSubmodules(gitDir, checkoutPath, rev)
+	err = PrepSubmodules(gitDir, checkoutPath, rev, timeout)
 	if err != nil {
 		return fmt.Errorf("failed to prep submodules: %v", err)
 	}

--- a/git.go
+++ b/git.go
@@ -24,7 +24,7 @@ func LocalMirror(url, gitDir, ref string, timeout time.Duration, messages io.Wri
 
 		if AlreadyHaveRef(gitDir, ref) {
 			// Sha already exists, don't need to fetch.
-			// log.Printf("Already have ref: %v %v", gitDir, ref)
+			// fmt.Fprintf(messages, "Already have ref: %v %v", gitDir, ref)
 			return nil
 		}
 

--- a/git.go
+++ b/git.go
@@ -156,13 +156,13 @@ func Describe(gitDir, ref string) (desc string, err error) {
 
 // RecursiveCheckout recursively checks out repositories; similar to "git clone
 // --recursive".
-func RecursiveCheckout(gitDir, checkoutPath, rev string, timeout time.Duration) error {
+func RecursiveCheckout(gitDir, checkoutPath, rev string, timeout time.Duration, messages io.Writer) error {
 	err := Checkout(gitDir, checkoutPath, rev)
 	if err != nil {
 		return fmt.Errorf("failed to checkout: %v", err)
 	}
 
-	err = PrepSubmodules(gitDir, checkoutPath, rev, timeout)
+	err = PrepSubmodules(gitDir, checkoutPath, rev, timeout, messages)
 	if err != nil {
 		return fmt.Errorf("failed to prep submodules: %v", err)
 	}

--- a/submodule.go
+++ b/submodule.go
@@ -3,7 +3,6 @@ package git
 import (
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -28,7 +27,7 @@ func PrepSubmodules(gitDir, checkoutDir, mainRev string, timeout time.Duration, 
 		return err
 	}
 
-	log.Printf("Prep %v submodules", len(submodules))
+	fmt.Fprintf(messages, "Prep %v submodules", len(submodules))
 
 	if err := GetSubmoduleRevs(gitDir, mainRev, submodules); err != nil {
 		return fmt.Errorf("GetSubmoduleRevs: %v", err)


### PR DESCRIPTION
One could argue a single global timeout would be more user-friendly and expected versus setting a timeout for each individual operation. However, this change does not intend to change the current behaviour.

This change keeps the behaviour of the CLI usage to use stderr, however removes the datetime prefix, which I believe complies more to user expectation.

One could argue that the additional parameter could be packed into a struct, or used by a struct's fields, or added to the `context` created. However, again, this should be done as a separate cleanup step imho.